### PR TITLE
Bug fixes + better byte packing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 default: lzw_test lzw_test_noisy lzw_pipe
 lzw_test: lzw.c lzw_test.c
-	gcc -Wall -Wextra -g3 --std=c99 -DDICTSIZE=260 -o $@ $^
+	gcc -Wall -Wextra -g3 --std=c99 -o $@ $^
 lzw_test_noisy: lzw_noisy.c lzw_test.c
-	gcc -Wall -Wextra -g3 --std=c99 -DDICTSIZE=260 -o $@ $^
+	gcc -Wall -Wextra -g3 --std=c99 -o $@ $^
 lzw_pipe: lzw.c lzw_pipe.c
-	gcc -Wall -Wextra -g3 --std=c99 -DDICTSIZE=260 -o $@ $^
+	gcc -Wall -Wextra -g3 --std=c99 -o $@ $^
 clean:
 	rm lzw_test lzw_test_noisy lzw_pipe

--- a/lzw.h
+++ b/lzw.h
@@ -9,7 +9,7 @@ struct dict_entry {
 };
 
 #if ! defined(DICTSIZE)
-#define DICTSIZE 4096
+#define DICTSIZE (1u << 16)
 #endif
 
 #if ! defined(SYMCOUNT)

--- a/lzw_pipe.c
+++ b/lzw_pipe.c
@@ -1,6 +1,9 @@
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
+#include <limits.h>
+#include <alloca.h>
 
 #include "lzw.h"
 
@@ -18,6 +21,49 @@ static int emit_char(void *p, unsigned char ch)
 	return 0;
 }
 
+static unsigned bytesPerSymbol()
+{
+	assert(DICTSIZE <= (1llu << (CHAR_BIT * sizeof(unsigned))));
+	unsigned symBytes = 0;
+	unsigned dictSize = DICTSIZE - 1;
+	while (dictSize)
+	{
+		symBytes++;
+		dictSize = dictSize >> CHAR_BIT;
+	}
+	return symBytes;
+}
+
+static void pack(unsigned *input, size_t nmemb, uint8_t *output)
+{
+	unsigned symBytes = bytesPerSymbol();
+	for (size_t i = 0; i < nmemb; i++)
+	{
+		for (unsigned b = 0; b < symBytes; b++)
+		{
+			output[i * symBytes + b] = (uint8_t)
+				((input[i] >> (CHAR_BIT * b)) & 0xff);
+		}
+	}
+}
+
+static void unpack(uint8_t *input, size_t nmemb, unsigned *output)
+{
+	unsigned symBytes = bytesPerSymbol();
+	size_t symCount = nmemb / symBytes;
+
+	for (size_t i = 0; i < symCount; i++)
+	{
+		unsigned value = 0;
+		for (unsigned b = 0; b < symBytes; b++)
+		{
+			value += input[i * symBytes + b] << (b * CHAR_BIT);
+		}
+
+		output[i] = value;
+	}
+}
+
 static int encode(void)
 {
 	struct lzw_state enc;
@@ -25,6 +71,8 @@ static int encode(void)
 
 	char input[1000];
 	unsigned compressed[1024];
+	unsigned symBytes = bytesPerSymbol();
+	uint8_t *writeBuffer = alloca(1024 * symBytes);
 	size_t len;
 	unsigned *comp_curs;
 	unsigned complen;
@@ -36,14 +84,16 @@ static int encode(void)
 			assert(!lzw_encode(&enc, emit_code, (void *)&comp_curs, input[i]));
 		complen = comp_curs - compressed;
 
-		if (fwrite(compressed, sizeof(unsigned), complen, stdout) != complen)
+		pack(compressed, complen, writeBuffer);
+		if (fwrite(writeBuffer, symBytes, complen, stdout) != complen)
 			return -1;
 	}
 
 	comp_curs = compressed;
 	assert(!lzw_encode_finish(&enc, emit_code, (void *) &comp_curs));
 	complen = comp_curs - compressed;
-	if (fwrite(compressed, sizeof(unsigned), complen, stdout) != complen)
+	pack(compressed, complen, writeBuffer);
+	if (fwrite(writeBuffer, symBytes, complen, stdout) != complen)
 		return -1;
 
 	return 0;
@@ -54,11 +104,14 @@ static int decode(void)
 	struct lzw_state dec;
 	lzw_state_init(&dec);
 
+	unsigned symBytes = bytesPerSymbol();
+	uint8_t *readBuffer = alloca(50 * symBytes);
 	unsigned input[50];
 	unsigned char output[1024];
 	size_t len;
 
-	while ((len = fread(input, sizeof(unsigned), 50, stdin)) > 0) {
+	while ((len = fread(readBuffer, symBytes, 50, stdin)) > 0) {
+		unpack(readBuffer, len * symBytes, input);
 		unsigned char *dec_curs = &output[0];
 		for(unsigned i = 0; i < len; i++)
 			assert(!lzw_decode(&dec, emit_char, (void *)&dec_curs, input[i]));

--- a/lzw_pipe.c
+++ b/lzw_pipe.c
@@ -29,7 +29,7 @@ static int encode(void)
 	unsigned *comp_curs;
 	unsigned complen;
 
-	while ((len = fread(input, 1, 1000, stdin)) > 0) {
+	while ((len = fread(input, sizeof(char), 1000, stdin)) > 0) {
 		comp_curs = &compressed[0];
 		complen = 0;
 		for(unsigned i = 0; i < len; i++)
@@ -64,7 +64,7 @@ static int decode(void)
 			assert(!lzw_decode(&dec, emit_char, (void *)&dec_curs, input[i]));
 		unsigned declen = dec_curs - output;
 
-		if (fwrite(output, sizeof(unsigned), declen, stdout) != declen)
+		if (fwrite(output, sizeof(char), declen, stdout) != declen)
 			return -1;
 	}
 


### PR DESCRIPTION
So I've got the compressed README to be smaller than the input!

`# cat README | ./lzw_pipe > README.out `
`# du -sb README*`
`2118	README`
`2030	README.out`